### PR TITLE
Update Driver.R

### DIFF
--- a/src/R/rDotNet/R/Driver.R
+++ b/src/R/rDotNet/R/Driver.R
@@ -95,8 +95,23 @@
             else
                 mono)
 
-            message ("NOTE: starting CLR server")
             system2 (exe, args, wait=FALSE, stderr=FALSE, stdout=FALSE)
+            Sys.sleep(2)
+            if (internal_ctest_connection (host, port))
+            {
+                message ("NOTE: started CLR server.")
+            }else{
+                args.nollvm <- gsub("--llvm", "--nollvm", args)
+                system2 (exe, args.nollvm, wait=FALSE, stderr=FALSE, stdout=FALSE)
+                Sys.sleep(1)
+                
+                if (internal_ctest_connection (host, port))
+                {
+                    message ("NOTE: started CLR server with --nollvm option.")
+                }else{
+                    message ("NOTE: starting CLR server failed; try command line.")
+                }
+            }
         }
         
         internal_cinit(host, port)


### PR DESCRIPTION
if `system2` call with arg `--llvm` failed try to start with `--nollvm` mono option. `Sys.sleep(2)` to elapse some time before checking if the CLRServer.exe is running.

tested on the following system:

## Linux
```
cp@fgcz-148:~ > mono -V
Mono JIT compiler version 5.20.1.19 (tarball Thu Apr 11 09:07:22 UTC 2019)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
        TLS:           __thread
        SIGSEGV:       altstack
        Notifications: epoll
        Architecture:  amd64
        Disabled:      none
        Misc:          softdebug
        Interpreter:   yes
        LLVM:          yes(600)
        Suspend:       hybrid
        GC:            sgen (concurrent by default)
cp@fgcz-148:~ > uname -a 
Linux fgcz-148 4.14.0-3-amd64 #1 SMP Debian 4.14.17-1 (2018-02-14) x86_64 GNU/Linux

```

```
R> library(rawDiag)
Loading required package: rDotNet
Registered S3 method overwritten by 'dplyr':
  method               from
  as.data.frame.tbl_df tibble
Registered S3 methods overwritten by 'ggplot2':
  method         from
  [.quosures     rlang
  c.quosures     rlang
  print.quosures rlang
Registered S3 method overwritten by 'rvest':
  method            from
  read_xml.response xml2
Package 'rawDiag' version 0.0.35
NOTE: started CLR server with --nollvm option.
R> sessionInfo()
R version 3.6.0 (2019-04-26)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Debian GNU/Linux buster/sid

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/atlas/libblas.so.3.10.3
LAPACK: /usr/lib/x86_64-linux-gnu/atlas/liblapack.so.3.10.3

Random number generation:
 RNG:     Mersenne-Twister
 Normal:  Inversion
 Sample:  Rounding

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C
 [9] LC_ADDRESS=C               LC_TELEPHONE=C
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods
[7] base

other attached packages:
[1] rawDiag_0.0.35 rDotNet_0.9.2

loaded via a namespace (and not attached):
 [1] tidyselect_0.2.5 purrr_0.2.5      haven_1.1.2
 [4] lattice_0.20-38  colorspace_1.3-2 testthat_2.0.0
 [7] yaml_2.2.0       blob_1.1.1       rlang_0.2.2
[10] hexbin_1.27.2    pillar_1.3.0     glue_1.3.0
[13] DBI_1.0.0        tidyverse_1.2.1  bit64_0.9-7
[16] modelr_0.1.2     readxl_1.1.0     bindrcpp_0.2.2
[19] protViz_0.4.0    bindr_0.1.1      plyr_1.8.4
[22] stringr_1.3.1    munsell_0.5.0    gtable_0.2.0
[25] cellranger_1.1.0 rvest_0.3.2      codetools_0.2-16
[28] memoise_1.1.0    forcats_0.3.0    parallel_3.6.0
[31] broom_0.5.0      Rcpp_0.12.18     readr_1.1.1
[34] scales_1.0.0     backports_1.1.2  jsonlite_1.5
[37] bit_1.1-14       ggplot2_3.0.0    hms_0.4.2
[40] digest_0.6.16    stringi_1.2.4    dplyr_0.7.7
[43] grid_3.6.0       tools_3.6.0      magrittr_1.5
[46] lazyeval_0.2.1   tibble_1.4.2     RSQLite_2.1.1
[49] crayon_1.3.4     tidyr_0.8.2      pkgconfig_2.0.2
[52] xml2_1.2.0       lubridate_1.7.4  assertthat_0.2.0
[55] httr_1.3.1       R6_2.2.2         nlme_3.1-139
[58] compiler_3.6.0
R> 
```

## Apple 

```
cp@fgcz-113:~ > mono -V
Mono JIT compiler version 5.2.0.224 (d15-3/14f2c81 Thu Aug 24 10:33:52 EDT 2017)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
	TLS:           normal
	SIGSEGV:       altstack
	Notification:  kqueue
	Architecture:  amd64
	Disabled:      none
	Misc:          softdebug 
	LLVM:          yes(3.6.0svn-mono-master/8b1520c)
	GC:            sgen (concurrent by default)
```

```
cp@fgcz-113:~ > ps aux | grep CLR
cp               34481   0.6  0.0  4268040    780 s018  S+    8:47PM   0:00.00 grep CLR
cp               34471   0.0  0.3  4383524  49928 s018  S     8:47PM   0:01.75 /Library/Frameworks/Mono.framework/Commands/mono64 --llvm /Users/cp/Library/R/3.5/library/rDotNet/server/bin/Debug/CLRServer.exe -url svc://localhost:56789/ -dll /Users/cp/Library/R/3.5/library/rawDiag/exec/fgcz_raw.dll
```

```
> library(rawDiag)
Loading required package: rDotNet
Package 'rawDiag' version 0.0.35
NOTE: started CLR server.
R> sessionInfo()
R version 3.5.1 (2018-07-02)
Platform: x86_64-apple-darwin15.6.0 (64-bit)
Running under: macOS  10.14.5

Matrix products: default
BLAS: /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libRblas.0.dylib
LAPACK: /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libRlapack.dylib

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods  
[7] base     

other attached packages:
[1] rawDiag_0.0.35 rDotNet_0.9.2 

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.0       cellranger_1.1.0 pillar_1.3.1    
 [4] compiler_3.5.1   plyr_1.8.4       tools_3.5.1     
 [7] forcats_0.3.0    testthat_2.0.1   digest_0.6.18   
[10] bit_1.1-14       lubridate_1.7.4  jsonlite_1.6    
[13] RSQLite_2.1.1    memoise_1.1.0    tibble_2.0.1    
[16] gtable_0.2.0     nlme_3.1-137     lattice_0.20-35 
[19] pkgconfig_2.0.2  rlang_0.3.1      DBI_1.0.0       
[22] protViz_0.4.3    yaml_2.2.0       parallel_3.5.1  
[25] haven_1.1.2      hexbin_1.27.2    xml2_1.2.0      
[28] stringr_1.4.0    httr_1.3.1       dplyr_0.8.0.1   
[31] hms_0.4.2        generics_0.0.2   bit64_0.9-7     
[34] grid_3.5.1       tidyselect_0.2.5 glue_1.3.0      
[37] R6_2.4.0         readxl_1.1.0     readr_1.1.1     
[40] modelr_0.1.2     ggplot2_3.1.0    purrr_0.3.1     
[43] tidyr_0.8.3      blob_1.1.1       magrittr_1.5    
[46] codetools_0.2-15 scales_1.0.0     backports_1.1.3 
[49] rvest_0.3.2      assertthat_0.2.0 tidyverse_1.2.1 
[52] colorspace_1.3-2 stringi_1.3.1    lazyeval_0.2.1  
[55] munsell_0.5.0    broom_0.5.1      crayon_1.3.4    
R> 
```